### PR TITLE
SprayMesh Extended - Fix sprays drawing twice and over translucent renderables

### DIFF
--- a/addons/spraymesh_extended/lua/spraymesh/client/cl_init.lua
+++ b/addons/spraymesh_extended/lua/spraymesh/client/cl_init.lua
@@ -881,8 +881,8 @@ hook.Add("PostDrawHUD", "SprayMesh.GenerateSprayPlaceholderTextures", function()
 end)
 
 -- Draw meshes for all player sprays
-hook.Add("PostDrawTranslucentRenderables", "SprayMesh.DrawSprays", function(isDrawingDepth, isDrawingSkybox, isDrawing3DSkybox)
-    if isDrawingDepth then return end
+hook.Add("PreDrawTranslucentRenderables", "SprayMesh.DrawSprays", function(isDrawingDepth, isDrawingSkybox, isDrawing3DSkybox)
+    if isDrawingDepth or isDrawingSkybox then return end
 
     -- If render order doesn't exist yet, rebuild it
     if not spraymesh.RENDER_ITER_CLIENT then


### PR DESCRIPTION
Fixes sprays also being drawn when the skybox draws and fixes sprays drawing over all translucent renderables.

#### Left prop has slight translucency, right prop has none.
![image](https://github.com/user-attachments/assets/df9c2c93-3890-4dbc-bbfa-9389b5e6b751)
